### PR TITLE
Add initial WebAssembly build sample

### DIFF
--- a/docs/webassembly.md
+++ b/docs/webassembly.md
@@ -1,0 +1,23 @@
+# WebAssembly support
+
+This repository contains an experimental target that demonstrates how PhotoBroom code can be compiled to WebAssembly.
+The `src/wasm` directory provides a simple "hello world" example that builds with Emscripten.
+
+## Building
+
+```
+emcmake cmake -S . -B build-wasm
+cmake --build build-wasm --target photobroom_wasm
+```
+
+The build uses the standard Emscripten toolchain. The resulting executable writes a greeting to the JavaScript console.
+
+## Next steps
+
+- Gradually expose PhotoBroom libraries to the WebAssembly target.
+- Integrate Qt for WebAssembly to provide a UI.
+- Provide a file-system abstraction suitable for browsers.
+- Implement continuous integration jobs for the web build.
+- Create examples demonstrating interaction between JavaScript and PhotoBroom code.
+
+This document will evolve as work on WebAssembly support progresses.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,10 @@ add_subdirectory(project_utils)
 add_subdirectory(unit_tests_utils)
 add_subdirectory(system)
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+    add_subdirectory(wasm)
+endif()
+
 add_executable(photo_broom
     config_storage.cpp
     config_storage.hpp

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_executable(photobroom_wasm main.cpp)

--- a/src/wasm/main.cpp
+++ b/src/wasm/main.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+
+int main()
+{
+    std::cout << "Hello from PhotoBroom WebAssembly!" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a simple WebAssembly hello world target
- enable wasm build when using the Emscripten toolchain
- document WebAssembly build instructions and future work

## Testing
- `cmake -S . -B build` *(fails: Git submodules were not updated)*

------
https://chatgpt.com/codex/tasks/task_e_689cdc78aeec8331b0009f40628a6dc1