### PR TITLE
Expand CI coverage across more platforms

### DIFF
--- a/.github/workflows/linux-arch-build.yml
+++ b/.github/workflows/linux-arch-build.yml
@@ -1,0 +1,110 @@
+name: Build-Linux-Arch
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: "Build PhotoBroom sources on Arch Linux"
+    runs-on: ubuntu-latest
+    container: archlinux:latest
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+          - { compiler: GNU, CC: gcc, CXX: g++ }
+        build: [Release]
+        shared: [TRUE, FALSE]
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+        lfs: false
+
+    - name: Install system dependencies
+      run: |
+        pacman -Syu --noconfirm &&      \
+        pacman -S --noconfirm           \
+          git                           \
+          cmake                         \
+          make                          \
+          gcc                           \
+          ninja                         \
+          python-cairosvg               \
+          python-defusedxml             \
+          python-pillow                 \
+          ffmpeg                        \
+          boost                         \
+          opencv                        \
+          openblas                      \
+          dlib                          \
+          gtest                         \
+          mesa                          \
+          libglvnd                      \
+          libwebp                       \
+          inih                          \
+          brotli
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: '6.7.2'
+        cache: 'true'
+        modules: 'qtmultimedia qtquick3d qtshadertools qtquicktimeline'
+
+    - name: Install CsLibGuarded
+      run: |
+        git clone -b libguarded-1.4.1 https://github.com/copperspice/cs_libguarded.git
+        cd cs_libguarded
+        mkdir build
+        cd build
+        cmake ..
+        cmake --build . --target all
+        cmake --build . --target install
+
+    - name: Install Exiv2
+      run: |
+        git clone -b v0.28.2 https://github.com/Exiv2/exiv2.git
+        cd exiv2
+        mkdir build
+        cd build
+        cmake .. -DEXIV2_ENABLE_VIDEO=ON -DEXIV2_BUILD_EXIV2_COMMAND=OFF -DEXIV2_BUILD_UNIT_TESTS=OFF -DEXIV2_BUILD_SAMPLES=OFF
+        cmake --build . --target all
+        cmake --build . --target install
+
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ github.job }}-${{ matrix.compiler.compiler }}
+
+    - name: Setup environment
+      run: |
+        echo "ENABLE_SANITIZERS=$( test ${{ matrix.build }} == \"Release\" && echo \"ON\" || echo \"OFF\" )" >> $GITHUB_ENV
+
+    - name: Build
+      uses: ashutoshvarma/action-cmake-build@master
+      with:
+        build-dir: ${{ runner.workspace }}/build
+        build-type: ${{ matrix.build }}
+        cc: ${{ matrix.compiler.CC }}
+        cxx: ${{ matrix.compiler.CXX }}
+        configure-options: |
+            -DBUILD_SHARED_LIBS=${{ matrix.shared }}
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            -DENABLE_SANITIZERS_FOR_TESTS=${{ env.ENABLE_SANITIZERS }}
+            -DPython=/usr/bin/python3
+        run-test: true
+        ctest-options: |
+            -LE HeavyData
+            --output-on-failure
+      env:
+        TSAN_OPTIONS: "suppressions:${{ runner.workspace }}/photobroom/sanitizer-thread-suppressions.txt"

--- a/.github/workflows/linux-fedora-build.yml
+++ b/.github/workflows/linux-fedora-build.yml
@@ -1,0 +1,111 @@
+name: Build-Linux-Fedora
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: "Build PhotoBroom sources on Fedora"
+    runs-on: ubuntu-latest
+    container: fedora:39
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+          - { compiler: GNU, CC: gcc, CXX: g++ }
+        build: [Release]
+        shared: [TRUE, FALSE]
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+        lfs: false
+
+    - name: Install system dependencies
+      run: |
+        dnf -y update &&              \
+        dnf -y install                \
+          git                         \
+          cmake                       \
+          make                        \
+          gcc                         \
+          gcc-c++                     \
+          ninja-build                 \
+          python3-cairosvg            \
+          python3-defusedxml          \
+          python3-pillow              \
+          ffmpeg-devel                \
+          boost-devel                 \
+          opencv-devel                \
+          openblas-devel              \
+          dlib-devel                  \
+          gtest-devel                 \
+          mesa-libGL-devel            \
+          libglvnd-devel              \
+          libwebp-devel               \
+          inih-devel                  \
+          brotli-devel
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: '6.7.2'
+        cache: 'true'
+        modules: 'qtmultimedia qtquick3d qtshadertools qtquicktimeline'
+
+    - name: Install CsLibGuarded
+      run: |
+        git clone -b libguarded-1.4.1 https://github.com/copperspice/cs_libguarded.git
+        cd cs_libguarded
+        mkdir build
+        cd build
+        cmake ..
+        cmake --build . --target all
+        cmake --build . --target install
+
+    - name: Install Exiv2
+      run: |
+        git clone -b v0.28.2 https://github.com/Exiv2/exiv2.git
+        cd exiv2
+        mkdir build
+        cd build
+        cmake .. -DEXIV2_ENABLE_VIDEO=ON -DEXIV2_BUILD_EXIV2_COMMAND=OFF -DEXIV2_BUILD_UNIT_TESTS=OFF -DEXIV2_BUILD_SAMPLES=OFF
+        cmake --build . --target all
+        cmake --build . --target install
+
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ github.job }}-${{ matrix.compiler.compiler }}
+
+    - name: Setup environment
+      run: |
+        echo "ENABLE_SANITIZERS=$( test ${{ matrix.build }} == \"Release\" && echo \"ON\" || echo \"OFF\" )" >> $GITHUB_ENV
+
+    - name: Build
+      uses: ashutoshvarma/action-cmake-build@master
+      with:
+        build-dir: ${{ runner.workspace }}/build
+        build-type: ${{ matrix.build }}
+        cc: ${{ matrix.compiler.CC }}
+        cxx: ${{ matrix.compiler.CXX }}
+        configure-options: |
+            -DBUILD_SHARED_LIBS=${{ matrix.shared }}
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            -DENABLE_SANITIZERS_FOR_TESTS=${{ env.ENABLE_SANITIZERS }}
+            -DPython=/usr/bin/python3
+        run-test: true
+        ctest-options: |
+            -LE HeavyData
+            --output-on-failure
+      env:
+        TSAN_OPTIONS: "suppressions:${{ runner.workspace }}/photobroom/sanitizer-thread-suppressions.txt"

--- a/.github/workflows/linux-ubuntu-22-build.yml
+++ b/.github/workflows/linux-ubuntu-22-build.yml
@@ -1,0 +1,105 @@
+name: Build-Linux-Ubuntu22
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: "Build PhotoBroom sources on Ubuntu 22.04"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+          - { compiler: GNU, CC: gcc, CXX: g++ }
+        build: [Release]
+        shared: [TRUE, FALSE]
+        os: [ubuntu-22.04]
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+        lfs: false
+
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update &&              \
+        sudo apt-get install                \
+          ninja-build                       \
+          python3-cairosvg                  \
+          python3-defusedxml                \
+          python3-pil                       \
+          libavformat-dev                   \
+          libboost-dev                      \
+          libopencv-dev                     \
+          libopenblas-dev                   \
+          libdlib-dev                       \
+          libgmock-dev                      \
+          libgl1-mesa-dev                   \
+          libglvnd-dev                      \
+          libwebp-dev
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: '6.7.2'
+        cache: 'true'
+        modules: 'qtmultimedia qtquick3d qtshadertools qtquicktimeline'
+
+    - name: Install CsLibGuarded
+      run: |
+        git clone -b libguarded-1.4.1 https://github.com/copperspice/cs_libguarded.git
+        cd cs_libguarded
+        mkdir build
+        cd build
+        cmake ..
+        cmake --build . --target all
+        sudo cmake --build . --target install
+
+    - name: Install Exiv2
+      run: |
+        sudo apt-get install libinih-dev libbrotli-dev
+        git clone -b v0.28.2 https://github.com/Exiv2/exiv2.git
+        cd exiv2
+        mkdir build
+        cd build
+        cmake .. -DEXIV2_ENABLE_VIDEO=ON -DEXIV2_BUILD_EXIV2_COMMAND=OFF -DEXIV2_BUILD_UNIT_TESTS=OFF -DEXIV2_BUILD_SAMPLES=OFF
+        cmake --build . --target all
+        sudo cmake --build . --target install
+
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ github.job }}-${{ matrix.compiler.compiler }}
+
+    - name: Setup environment
+      run: |
+        echo "ENABLE_SANITIZERS=$( test ${{ matrix.build }} == \"Release\" && echo \"ON\" || echo \"OFF\" )" >> $GITHUB_ENV
+
+    - name: Build
+      uses: ashutoshvarma/action-cmake-build@master
+      with:
+        build-dir: ${{ runner.workspace }}/build
+        build-type: ${{ matrix.build }}
+        cc: ${{ matrix.compiler.CC }}
+        cxx: ${{ matrix.compiler.CXX }}
+        configure-options:
+            -DBUILD_SHARED_LIBS=${{ matrix.shared }}
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            -DENABLE_SANITIZERS_FOR_TESTS=${{ env.ENABLE_SANITIZERS }}
+            -DPython=/usr/bin/python3
+        run-test: true
+        ctest-options:
+            -LE HeavyData
+            --output-on-failure
+      env:
+        TSAN_OPTIONS=suppressions: ${{ runner.workspace }}/photobroom/sanitizer-thread-suppressions.txt

--- a/.github/workflows/macos-14-build.yml
+++ b/.github/workflows/macos-14-build.yml
@@ -1,0 +1,52 @@
+name: Build-MacOS-14
+
+on:
+  push:
+    branches:
+      - master
+      - macos_build
+  pull_request:
+
+jobs:
+  build:
+    name: "Build PhotoBroom sources on MacOS 14"
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14]
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Install system dependencies
+      run: |
+        brew link --overwrite pkgconf
+        brew install        \
+          llvm              \
+          dlib              \
+          exiv2             \
+          opencv            \
+          qt6
+
+    - name: Install CsLibGuarded
+      run: |
+        git clone -b libguarded-1.4.1 https://github.com/copperspice/cs_libguarded.git
+        cd cs_libguarded
+        mkdir build
+        cd build
+        cmake ..
+        cmake --build . --target all
+        sudo cmake --build . --target install
+
+    - name: Build
+      uses: ashutoshvarma/action-cmake-build@master
+      with:
+        build-dir: ${{ runner.workspace }}/build
+        build-type: Release
+        configure-options: -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON
+      env:
+        VERBOSE: 1


### PR DESCRIPTION
## Summary
- add workflow to build and test on Ubuntu 22.04
- add workflow to build on macOS 14
- add Fedora workflow via Docker to exercise build and tests
- add Arch Linux workflow via Docker for additional coverage

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/linux-ubuntu-22-build.yml")'`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/macos-14-build.yml")'`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/linux-fedora-build.yml")'`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/linux-arch-build.yml")'`
- `pip install pyyaml` *(fails: Could not find a version that satisfies the requirement pyyaml)*

------
https://chatgpt.com/codex/tasks/task_e_689cdb21b7408331a962d613f372aff7