### PR TITLE
Use breakpad for crash catching

### DIFF
--- a/docs/build.txt
+++ b/docs/build.txt
@@ -18,7 +18,8 @@ Required tools and libraries:
  - cs-libguarded*
  - ImageMagick**
 
- Optional libraries:
+Optional libraries:
+ - Breakpad (for crash catching)
  - KCrash + drkonqi (for crash catching)
 
  Packages, libraries and other components kept as git submodules:

--- a/src/crash_catcher/CMakeLists.txt
+++ b/src/crash_catcher/CMakeLists.txt
@@ -3,6 +3,9 @@ include(GenerateExportHeader)
 
 find_package(KF6Crash QUIET)
 
+find_path(BREAKPAD_INCLUDE_DIR NAMES client/linux/handler/exception_handler.h)
+find_library(BREAKPAD_LIB NAMES breakpad_client)
+
 include_directories(${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/src)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -13,7 +16,15 @@ set(CRASH_HANDLER_FOUND FALSE)
 set(CRASH_HANDLER_SOURCES)
 set(CRASH_HANDLER_LIBRARIES)
 
-if(KF5Crash_FOUND)
+if(BREAKPAD_INCLUDE_DIR AND BREAKPAD_LIB)
+
+    include_directories(SYSTEM ${BREAKPAD_INCLUDE_DIR})
+
+    set(CRASH_HANDLER_SOURCES crash_catcher_breakpad.cpp)
+    set(CRASH_HANDLER_LIBRARIES ${BREAKPAD_LIB})
+    set(CRASH_HANDLER_FOUND TRUE)
+
+elseif(KF5Crash_FOUND)
 
     include_directories(SYSTEM $<TARGET_PROPERTY:KF5::Crash,INTERFACE_INCLUDE_DIRECTORIES>)
 
@@ -22,7 +33,7 @@ if(KF5Crash_FOUND)
     set(CRASH_HANDLER_FOUND TRUE)
 
 else()
-    
+
     set(CRASH_HANDLER_SOURCES crash_catcher_null.cpp)
 
 endif()

--- a/src/crash_catcher/crash_catcher_breakpad.cpp
+++ b/src/crash_catcher/crash_catcher_breakpad.cpp
@@ -1,0 +1,25 @@
+#include "crash_catcher.hpp"
+
+#include <client/linux/handler/exception_handler.h>
+#include <filesystem>
+#include <memory>
+
+namespace {
+std::unique_ptr<google_breakpad::ExceptionHandler> g_handler;
+}
+
+bool CrashCatcher::internal_init()
+{
+    try
+    {
+        const auto dump_dir = std::filesystem::temp_directory_path() / CrashCatcher::name();
+        std::filesystem::create_directories(dump_dir);
+        google_breakpad::MinidumpDescriptor descriptor(dump_dir.string());
+        g_handler = std::make_unique<google_breakpad::ExceptionHandler>(descriptor, nullptr, nullptr, nullptr, true, -1);
+        return true;
+    }
+    catch(const std::exception &)
+    {
+        return false;
+    }
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -35,6 +35,7 @@
     },
     "qtdeclarative",
     "qtmultimedia",
-    "qtquick3d"
+    "qtquick3d",
+    "breakpad"
   ]
 }


### PR DESCRIPTION
## Summary
- add Breakpad as crash handler implementation
- detect Breakpad in crash_catcher build logic and link when available
- document Breakpad as optional dependency

## Testing
- `cmake -S . -B build` *(fails: Git submodules were not updated)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*


------
https://chatgpt.com/codex/tasks/task_e_689cdb5f05648331972db3525f0802f2