### PR TITLE
Install NSIS during Windows release packaging

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -76,10 +76,6 @@ jobs:
       with:
         vcpkgJsonGlob: vcpkg.json
 
-    - name: Install NSIS
-      if: matrix.config.name == 'release'
-      run: choco install nsis --no-progress -y
-
     - name: Build
       uses: lukka/run-cmake@v10
       with:
@@ -95,7 +91,9 @@ jobs:
 
     - name: Make package
       if: matrix.config.name == 'release'
-      run: cmake --build --target package --preset "${{ matrix.config.cmake_build }}"
+      run: |
+        choco install nsis --no-progress -y
+        cmake --build --target package --preset "${{ matrix.config.cmake_build }}"
 
     - name: Upload artifact
       if: matrix.config.name == 'release'


### PR DESCRIPTION
## Summary
- ensure the Windows release build installs NSIS before packaging so cpack can produce the installer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df62c961348331a44d32236f7d0b31