### PR TITLE
Add manual vcpkg binary cache to Windows workflow

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -19,6 +19,8 @@ jobs:
   build-dependencies:
     name: "Build PhotoBroom dependencies for Windows"
     runs-on: windows-latest
+    env:
+      VCPKG_DEFAULT_BINARY_CACHE: ${{ runner.temp }}\\vcpkg-binary-cache
     strategy:
       fail-fast: true
 
@@ -26,6 +28,20 @@ jobs:
     - uses: actions/checkout@v5
       with:
         submodules: true
+
+    - name: Prepare vcpkg binary cache
+      shell: pwsh
+      run: |
+        # TODO: Remove the manual cache once GitHub cache regression is fixed.
+        New-Item -ItemType Directory -Force -Path "${{ env.VCPKG_DEFAULT_BINARY_CACHE }}" | Out-Null
+
+    - name: Cache vcpkg artifacts
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
+        key: vcpkg-binary-${{ runner.os }}-${{ hashFiles('vcpkg.json') }}
+        restore-keys: |
+          vcpkg-binary-${{ runner.os }}-
 
     # built dependencies will be cached and reused in later jobs
     - name: Run vcpkg
@@ -38,6 +54,8 @@ jobs:
     name: "Build PhotoBroom sources on Windows"
     needs: build-dependencies
     runs-on: windows-latest
+    env:
+      VCPKG_DEFAULT_BINARY_CACHE: ${{ runner.temp }}\\vcpkg-binary-cache
     strategy:
       fail-fast: false
       matrix:
@@ -58,6 +76,20 @@ jobs:
     - uses: actions/checkout@v5
       with:
         submodules: true
+
+    - name: Prepare vcpkg binary cache
+      shell: pwsh
+      run: |
+        # TODO: Remove the manual cache once GitHub cache regression is fixed.
+        New-Item -ItemType Directory -Force -Path "${{ env.VCPKG_DEFAULT_BINARY_CACHE }}" | Out-Null
+
+    - name: Cache vcpkg artifacts
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
+        key: vcpkg-binary-${{ runner.os }}-${{ hashFiles('vcpkg.json') }}
+        restore-keys: |
+          vcpkg-binary-${{ runner.os }}-
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v4


### PR DESCRIPTION
## Summary
- configure the Windows jobs to populate and reuse a dedicated vcpkg binary cache
- add TODO comments so the manual caching workaround can be removed once GitHub resolves the regression

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dfc2e68bb08331a8df0f76a03f28eb